### PR TITLE
Tell Finder to empty trash instead of rm -rf

### DIFF
--- a/Eva.widget/index.coffee
+++ b/Eva.widget/index.coffee
@@ -698,7 +698,7 @@ afterRender: (domEl) ->
     $(domEl).on 'click', '.iTunesNext', => @run "osascript -e 'tell application \"iTunes\" to next track'"
     $(domEl).on 'click', '.iTunesPause', => @run "osascript -e 'tell application \"iTunes\" to pause'"
     $(domEl).on 'click', '.iTunesPlay', => @run "osascript -e 'tell application \"iTunes\" to play'"
-    $(domEl).on 'click', '#TrashCell', => @run "rm -rf ~/.Trash/* && rm -rf ~/.Trash/.*"
+    $(domEl).on 'click', '#TrashCell', => @run "osascript -e 'tell application \"Finder\" to empty'"
 #   Command to open up mounted volumes
     $(domEl).on 'click', '#66', => @run "ls /Volumes/ | awk -F'\t' '{ print $0}' > tmp.txt;i=1; cat tmp.txt | while read line; do if [ \"$i\" -eq 1 ]; then open /Volumes/\"${line}\"; fi; let i=i+1; done; rm tmp.txt
 "


### PR DESCRIPTION
I had an issue on my machine with `rm -rf` for the Trash folder throwing a permission denied. Luckily, Finder can be told to empty the trash. I followed your osascript pattern to tell Finder to empty. Cheers!
